### PR TITLE
Add Thank You step to onboarding flow

### DIFF
--- a/src/views/onboarding/100_ThankYou.tsx
+++ b/src/views/onboarding/100_ThankYou.tsx
@@ -1,0 +1,40 @@
+import { Typography } from "@mui/material";
+import Button from "../../components/onboarding/Button";
+import Step from "../../components/onboarding/Step";
+import { useAppStore } from "../../store/appStore";
+
+const STEP = 100;
+
+interface ThankYouProps {
+  className?: string;
+  lastEntry?: boolean;
+}
+
+export default function ThankYou({ className, lastEntry }: ThankYouProps) {
+  const resetStore = useAppStore((state) => state.resetStore);
+
+  return (
+    <Step
+      className={`ThankYou${className ? ` ${className}` : ""}`}
+      onboardingStep={STEP}
+      title="You made it to the end!"
+      text={
+        <Typography
+          variant="body1"
+          sx={{
+            fontSize: "0.95rem",
+            lineHeight: 1.6,
+            color: "#333",
+          }}
+        >
+          Thank you for completing the onboarding and helping test this release. Your time and feedback help us improve the VPN and make it better for everyone.
+        </Typography>
+      }
+      buttons={
+        lastEntry ? (
+          <Button label="Close" onClick={resetStore} />
+        ) : null
+      }
+    />
+  );
+}

--- a/src/views/onboarding/99_Feedback.tsx
+++ b/src/views/onboarding/99_Feedback.tsx
@@ -18,7 +18,7 @@ export default function Feedback({ className }: FeedbackProps) {
   const isMacOs = useAppStore((state) => state.isMacOs);
   const isSameDevice = useAppStore((state) => state.isSameDevice);
   const saveFeedback = useAppStore((state) => state.saveFeedback);
-  const resetStore = useAppStore((state) => state.resetStore);
+  const setOnboardingStep = useAppStore((state) => state.setOnboardingStep);
   const [loading, setLoading] = useState(false);
   
 
@@ -34,7 +34,7 @@ export default function Feedback({ className }: FeedbackProps) {
     setLoading(true);
     await uploadData(token, { onboardingStep, stepLog, notes, feedback, onboardingAnswers, isMacOs, isSameDevice });
     localStorage.removeItem('gvso_authToken');
-    resetStore();
+    setOnboardingStep(100);
   };
 
   return (

--- a/src/views/onboarding/index.tsx
+++ b/src/views/onboarding/index.tsx
@@ -45,6 +45,7 @@ import TryDifferentExitNode from "./43_TryDifferentExitNode";
 import WrapUp from "./44_WrapUp";
 import Summary from "./98_summary";
 import Feedback from "./99_Feedback";
+import ThankYou from "./100_ThankYou";
 
 export const STEP_NAMES: Record<number, string> = {
   1: "Welcome",
@@ -92,7 +93,8 @@ export const STEP_NAMES: Record<number, string> = {
   43: "Try Different Exit Node",
   44: "Wrap Up",
   98: "Summary",
-  99: "Feedback Form"
+  99: "Feedback Form",
+  100: "Thank You"
 };
 
 export const STEP_COMPONENTS: Record<number, React.ComponentType<any>> = {
@@ -141,5 +143,6 @@ export const STEP_COMPONENTS: Record<number, React.ComponentType<any>> = {
   43: TryDifferentExitNode,
   44: WrapUp,
   98: Summary,
-  99: Feedback
+  99: Feedback,
+  100: ThankYou
 };


### PR DESCRIPTION
## Summary
Added a new final step (step 100) to the onboarding flow that displays a thank you message to users after they complete the feedback form. This provides better closure to the onboarding experience.

## Key Changes
- Created new `ThankYou` component (`src/views/onboarding/100_ThankYou.tsx`) that displays a thank you message with optional close button
- Updated onboarding index to register the new step in `STEP_NAMES` and `STEP_COMPONENTS` mappings
- Modified `Feedback` component to navigate to step 100 instead of immediately resetting the store when feedback is submitted
- Changed `Feedback` to use `setOnboardingStep` instead of `resetStore` for better control over the flow

## Implementation Details
- The `ThankYou` component accepts optional `className` and `lastEntry` props to control styling and button visibility
- The close button only appears when `lastEntry` is true, allowing flexibility in how the step is used
- Feedback submission now transitions to the thank you page rather than immediately closing the onboarding flow
- The thank you message thanks users for completing onboarding and providing feedback

https://claude.ai/code/session_01XZv2TCCJX7ifRBWgzroSGt